### PR TITLE
Accept multibyte object name in GCS URL

### DIFF
--- a/lib/gcs/version.rb
+++ b/lib/gcs/version.rb
@@ -1,3 +1,3 @@
 class Gcs
-  VERSION = "0.1.0"
+  VERSION = "0.0.5"
 end

--- a/spec/gcs_spec.rb
+++ b/spec/gcs_spec.rb
@@ -5,6 +5,28 @@ describe Gcs do
     expect(Gcs::VERSION).not_to be nil
   end
 
+  describe ".ensure_bucket_object" do
+    describe "with bucket and object" do
+      it do
+        expect(Gcs.ensure_bucket_object("bucket", "Object")).to eql(["bucket", "Object"])
+      end
+    end
+
+    describe "with GCS URL" do
+      describe "ASCII Only" do
+        it do
+          expect(Gcs.ensure_bucket_object("gs://bucket/path/to/object")).to eql(["bucket", "path/to/object"])
+        end
+      end
+
+      describe "Multi bytes characters in object name" do
+        it do
+          expect(Gcs.ensure_bucket_object("gs://bucket/path/to/\u3042")).to eql(["bucket", "path/to/\u3042"])
+        end
+      end
+    end
+  end
+
   describe "read_partial" do
     before do
       skip "credential required." unless @credential_available


### PR DESCRIPTION
Gcs#_ensure_bucket_object raised an error when you pass GCS URL contains non-ASCII characters.
Though bucket name cannot contains non-ASCII characters, object name can contains arbitrary (?) UTF-8 characters.

On this opportunity I refactored Gcs#_ensure_bucket_object to the class method Gcs.ensure_bucket_object because it doesn't depend on any instance's state at all.

- @kamito 
- @minimum2scp 