### PR TITLE
Fix/read partial with trim after last delimiter without any delimiter

### DIFF
--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -77,6 +77,11 @@ class Gcs
             end
             if trim_after_last_delimiter
               i = total.rindex(trim_after_last_delimiter.force_encoding(Encoding::ASCII_8BIT))
+              if i.nil?
+                # If no delimiter was found, return empty string.
+                # This is because caller expect not to incomplete line. (ex: Newline Delimited JSON)
+                i = -1
+              end
               total[(i+1)..-1] = ""
             end
             return total

--- a/lib/gcs/version.rb
+++ b/lib/gcs/version.rb
@@ -1,3 +1,3 @@
 class Gcs
-  VERSION = "0.0.5"
+  VERSION = "0.0.7"
 end

--- a/spec/gcs_spec.rb
+++ b/spec/gcs_spec.rb
@@ -36,5 +36,11 @@ describe Gcs do
       buf = @api.read_partial("gs://gcp-public-data-landsat/index.csv.gz", limit: 100)
       expect(buf.bytesize).to be < 4*1024
     end
+    context "trim_after_last_delimiter without matching delimiter" do
+      it "return empty string" do
+        buf = @api.read_partial("gs://gcp-public-data-landsat/index.csv.gz", limit: 1, trim_after_last_delimiter: "x00")
+        expect(buf.bytesize).to eql(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Gcs#read_partial with keyword argument `trim_after_last_delimiter` returned incomplete line if the matched delimiter was not found in buffer.
The main purpose of this keyword argument is to prevent read incomplete line for a certain liner format (CSV, Newline Delimited JSON etc...).
If the buffer doesn't contain any delimiter, read_partial should return "".
