### PR TITLE
fix bug in Gcs#read_partial: escape space as %20.

### DIFF
--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -57,7 +57,7 @@ class Gcs
 
   def read_partial(bucket, object=nil, limit: 1024*1024, trim_after_last_delimiter: nil, &blk)
     bucket, object = _ensure_bucket_object(bucket, object)
-    uri = URI("https://www.googleapis.com/download/storage/v1/b/#{CGI.escape(bucket)}/o/#{CGI.escape(object)}?alt=media")
+    uri = URI("https://www.googleapis.com/download/storage/v1/b/#{CGI.escape(bucket)}/o/#{CGI.escape(object).gsub("+", "%20")}?alt=media")
     Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
       req = Net::HTTP::Get.new(uri.request_uri)
       req["Authorization"] = "Bearer #{@api.authorization.access_token}"


### PR DESCRIPTION
It seems that escaping SPACE as `+` doesn't work in Cloud Storage API.

As you can see https://github.com/ruby/ruby/blob/v2_3_5/lib/cgi/util.rb#L8-L13 CGI.escape escapes all characters except alphabets, digits and `.`, `-`, `_`.
So the `+` in the string from CGI.escape always means SPACE in original string. I implement to re-escape it to `%20`.

