### PR TITLE
Gcs#remove_tree should accept URL like 'gs://bucket/'

### DIFF
--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -149,7 +149,9 @@ class Gcs
 
   def remove_tree(gcs_url)
     bucket, path = self.class.ensure_bucket_object(gcs_url)
-    path = path + "/" unless path[-1] == "/"
+    if path.size > 0 and path[-1] != "/"
+      path = path + "/"
+    end
     next_page_token = nil
     loop do
       begin


### PR DESCRIPTION
Currently `gcs.remove_tree("gs://myBucket/")` remove no object because the object prefix would become "/".
I'd like to accept object prefix `""` to indicate `all objects in the bucket`.

Note that `gcs.remove_tree("gs://myBucket/")` will not remove the bucket `myBucket`.
