### PR TITLE
Fix typo in multiple rewrite requests.

### DIFF
--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -151,7 +151,7 @@ class Gcs
   def rewrite(src_bucket, src_object, dest_bucket, dest_object)
     r = @api.rewrite_object(src_bucket, src_object, dest_bucket, dest_object)
     until r.done
-      r = @api.rewrite_object(src_bucket, src_object, dest_bucket, dest_object, rewite_token: r.rewrite_token)
+      r = @api.rewrite_object(src_bucket, src_object, dest_bucket, dest_object, rewrite_token: r.rewrite_token)
     end
     r
   end


### PR DESCRIPTION
GCS rewrite API requires multiple request with `rewrite_token` to continue copying when source and destination buckets' region or storage classes are different.

https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite

This PR fixes a typo in such a case.