### PR TITLE
Gcs#get_object with :download_dest now return Google::Apis::StorageV1::Object object.

### DIFF
--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -76,7 +76,11 @@ class Gcs
   def get_object(bucket, object=nil, download_dest: nil)
     bucket, object = _ensure_bucket_object(bucket, object)
     begin
-      @api.get_object(bucket, object, download_dest: download_dest)
+      obj = @api.get_object(bucket, object)
+      if download_dest
+        @api.get_object(bucket, object, generation: obj.generation, download_dest: download_dest)
+      end
+      obj
     rescue Google::Apis::ClientError
       if $!.status_code == 404
         return nil


### PR DESCRIPTION
I've miss a commit in https://github.com/groovenauts/gcs-ruby/pull/13.

Gcs#get_object now always return Google::Apis::StorageV1::Object, even when :download_dest was specified.
