### PR TITLE
add  kearg of Gcs.new. set default retries to 10.

### DIFF
--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -9,8 +9,9 @@ require "google/apis/storage_v1"
 
 class Gcs
   include Google::Apis::StorageV1
-  def initialize(email_address = nil, private_key = nil, scope: "cloud-platform")
+  def initialize(email_address = nil, private_key = nil, scope: "cloud-platform", request_options: {retries: 10})
     @api = Google::Apis::StorageV1::StorageService.new
+    @api.request_options = @api.request_options.merge(request_options)
     scope_url = "https://www.googleapis.com/auth/#{scope}"
     if email_address and private_key
       auth = Signet::OAuth2::Client.new(


### PR DESCRIPTION
Add keyword argument `request_options` of Gcs.new.
You can modify request_options of Google::Api::Client API.
And set default value of `retries` to 10 instead of 0, the default value of google-api-client.gem.

- @kamito 
- @nakanori 
- @minimum2scp 