### PR TITLE
Add Gcs#glob method.

### DIFF
--- a/spec/gcs_spec.rb
+++ b/spec/gcs_spec.rb
@@ -74,4 +74,18 @@ describe Gcs do
       end
     end
   end
+
+  describe "#glob" do
+    before do
+      skip "credential required." unless @credential_available
+      @api = Gcs.new(@email, @private_key)
+    end
+    let(:pattern){ "gs://gcp-public-data-landsat/LC08/01/101/240/*/*.TIF" }
+    it "yields matched objects" do
+      items = []
+      @api.glob(pattern) {|obj| items << obj.name }
+      expect(items.size).to eql(36)
+      expect(items.all?{|name| File.fnmatch("LC08/01/101/240/*/*.TIF", name) }).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Please use this method carefully. It can call list_objects API too many times to search matching objects.
For example, `gcs.glob("gs://mybucket/*/a.txt")` searching *ALL Objects* under the bucket `mybucket`, even though there is no objects under nested folders.

Gcs#glob doesn't match 'phantom directories'.
I mean, if you have an object `gs://mybucket/a/b/c` but don't have `gs://mybucket/a/b/`, Gcs#glob with a pattern `gs://mybucket/a/*` doesn't yield `gs://mybucket/a/b/`

- @kamito 
- @nakanori 
- @minimum2scp 