### PR TITLE
Add compose_object API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,9 @@ gcs.read_partial("gs://myBucket/myObject", limit: 1024, trim_after_last_delimite
 # origin_domain keyword arg was for CORS setting.
 gcs.initiate_resumable_upload("myBucket", "myObject", content_type: "text/plain", origin_domain: "http://example.com")
 gcs.initiate_resumable_upload("gs://myBucket/myObject", content_type: "text/plain", origin_domain: "http://example.com")
+
+# compose objects
+gcs.compose_object(["gs://myBucket/myObject-1", "gs://myBucket/myObject-2"], "gs://myBucket/composedObject")
+gcs.compose_object("gs://myBucket/myObject-*", "gs://myBucket/composedObject")
 ```
 

--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -187,7 +187,7 @@ class Gcs
     self.rewrite(src_bucket, src_path, dest_bucket, dest_path)
   end
 
-  def compose_object(source_objs, dest)
+  def compose_object(source_objs, dest, content_type: nil, content_encoding: nil)
     source_objs = Array(source_objs)
     if source_objs.size > 32
       raise "The number of components to be composed into single object should be equal or less than 32."
@@ -213,8 +213,13 @@ class Gcs
       end
       sobjs |= matched_names
     end
+    dest_obj = Google::Apis::StorageV1::Object.new(
+      bucket: dest_bucket,
+      name: dest_object,
+      content_type: content_type,
+      content_encoding: content_encoding)
     @api.compose_object(dest_bucket, dest_object,
-                        Google::Apis::StorageV1::ComposeRequest.new(destination: Google::Apis::StorageV1::Object.new(bucket: dest_bucket, name: dest_object),
+                        Google::Apis::StorageV1::ComposeRequest.new(destination: dest_obj,
                                                                     source_objects: sobjs.map{|so| Google::Apis::StorageV1::ComposeRequest::SourceObject.new(name: so) }))
   end
 

--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -187,6 +187,37 @@ class Gcs
     self.rewrite(src_bucket, src_path, dest_bucket, dest_path)
   end
 
+  def compose_object(source_objs, dest)
+    source_objs = Array(source_objs)
+    if source_objs.size > 32
+      raise "The number of components to be composed into single object should be equal or less than 32."
+    end
+    dest_bucket, dest_object = self.class.ensure_bucket_object(dest)
+    source_bucket = nil
+    sobjs = []
+    source_objs.each do |spat|
+      b, _ = self.class.ensure_bucket_object(spat)
+      source_bucket ||= b
+      unless source_bucket == b and source_bucket == dest_bucket
+        raise "The all components objects should be placed in the same bucket to compose objects."
+      end
+      matched_names = []
+      glob(spat) do |obj|
+        matched_names << obj.name
+        if (sobjs | matched_names).size > 32
+          raise "The number of components to be composed into single object should be equal or less than 32."
+        end
+      end
+      if matched_names.empty?
+        raise "No object found or no matched objects found for '#{spat}'"
+      end
+      sobjs |= matched_names
+    end
+    @api.compose_object(dest_bucket, dest_object,
+                        Google::Apis::StorageV1::ComposeRequest.new(destination: Google::Apis::StorageV1::Object.new(bucket: dest_bucket, name: dest_object),
+                                                                    source_objects: sobjs.map{|so| Google::Apis::StorageV1::ComposeRequest::SourceObject.new(name: so) }))
+  end
+
   def remove_tree(gcs_url)
     bucket, path = self.class.ensure_bucket_object(gcs_url)
     if path.size > 0 and path[-1] != "/"

--- a/spec/gcs_spec.rb
+++ b/spec/gcs_spec.rb
@@ -84,7 +84,7 @@ describe Gcs do
     it "yields matched objects" do
       items = []
       @api.glob(pattern) {|obj| items << obj.name }
-      expect(items.size).to eql(36)
+      expect(items.size).to eql(108)
       expect(items.all?{|name| File.fnmatch("LC08/01/101/240/*/*.TIF", name) }).to be(true)
     end
   end


### PR DESCRIPTION
Support compose_object.
See README.md for the usage.

```
# compose objects
gcs.compose_object(["gs://myBucket/myObject-1", "gs://myBucket/myObject-2"], "gs://myBucket/composedObject")
gcs.compose_object("gs://myBucket/myObject-*", "gs://myBucket/composedObject")
```

