### PR TITLE
Implement Gcs::GcsWriter

### DIFF
--- a/lib/gcs.rb
+++ b/lib/gcs.rb
@@ -7,6 +7,8 @@ require "json"
 require "gcs/version"
 require "google/apis/storage_v1"
 
+require_relative "gcs/gcs_writer"
+
 class Gcs
   include Google::Apis::StorageV1
   def initialize(email_address = nil, private_key = nil, scope: "cloud-platform", request_options: {retries: 10})

--- a/lib/gcs/gcs_writer.rb
+++ b/lib/gcs/gcs_writer.rb
@@ -1,11 +1,6 @@
 # coding: utf-8
 
 require "net/http"
-require "cgi"
-require "json"
-
-require "gcs/version"
-require "google/apis/storage_v1"
 
 class Gcs
   class GcsWriter

--- a/lib/gcs/gcs_writer.rb
+++ b/lib/gcs/gcs_writer.rb
@@ -1,0 +1,91 @@
+# coding: utf-8
+
+require "net/http"
+require "cgi"
+require "json"
+
+require "gcs/version"
+require "google/apis/storage_v1"
+
+class Gcs
+  class GcsWriter
+    # GCS resumable upload chunk size should be 256 KB (https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload#example_uploading_the_file)
+    class ServerError < RuntimeError
+    end
+    CHUNK_SIZE = 256 * 1024
+
+    def initialize(gcs_api, bucket, object=nil, content_type: "application/octet-stream", origin_domain: nil)
+      @session_url = gcs_api.initiate_resumable_upload(bucket, object, content_type: content_type, origin_domain: origin_domain)
+      @pos = 0
+      @buf = "".force_encoding(Encoding::ASCII_8BIT)
+      uri = URI(@session_url)
+      @path = uri.path + "?" + uri.query
+      @http = Net::HTTP.new(uri.host, uri.port)
+      @http.use_ssl = true
+      @closed = false
+    end
+
+    attr_reader :pos, :closed
+    alias :closed? :closed
+
+    def start(&blk)
+      begin
+        blk.call(self)
+      ensure
+        close
+      end
+    end
+
+    def put_chunk
+      len = [CHUNK_SIZE, @buf.bytesize].min
+      send_buf = @buf[0, len]
+      if len < CHUNK_SIZE
+        total_size = @pos + len
+        closed = true
+      else
+        total_size = "*"
+        closed = false
+      end
+      if len == 0
+        range = "*"
+      else
+        range = "#{@pos}-#{@pos+len-1}"
+      end
+      res = @http.start{|h|
+        h.put(@path, send_buf, {"Content-Range" => "bytes #{range}/#{total_size}", "Content-Length" => "#{len}" })
+      }
+      if closed
+        expected_code = [200, 201]
+      else
+        expected_code = [308]
+      end
+      # see 'Handling errors' section in https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload#handling_errors
+      unless expected_code.include?(res.code.to_i)
+        if res.code.to_i > 500
+          raise ServerError, "server error at putting a chunk in resumable upload: status=#{res.code}\n" + res.body.to_s
+        else
+          raise "Unexpected error at putting a chunk in resumable upload: status=#{res.code}\n" + res.body.to_s
+        end
+      end
+      @closed = closed
+      @buf[0, len] = ""
+      @pos += len
+    end
+
+    def close
+      unless @closed
+        put_chunk
+      end
+    end
+
+    def write(str)
+      if @closed
+        raise "Write to closed stream."
+      end
+      @buf << str.to_s.dup.force_encoding(Encoding::ASCII_8BIT)
+      while @buf.bytesize >= CHUNK_SIZE
+        put_chunk
+      end
+    end
+  end
+end

--- a/spec/gcs_spec.rb
+++ b/spec/gcs_spec.rb
@@ -84,7 +84,7 @@ describe Gcs do
     it "yields matched objects" do
       items = []
       @api.glob(pattern) {|obj| items << obj.name }
-      expect(items.size).to eql(228)
+      expect(items.size).to eql(252)
       expect(items.all?{|name| File.fnmatch("LC08/01/101/240/*/*.TIF", name) }).to be(true)
     end
   end

--- a/spec/gcs_writer_spec.rb
+++ b/spec/gcs_writer_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe Gcs::GcsWriter do
+  before do
+    @gcs_api = double(:gcs_api)
+    @session_url = "https://www.example.com/path?session=xxxxx"
+    @http = double(:http)
+    allow(@gcs_api).to receive(:initiate_resumable_upload).and_return(@session_url)
+    expect(Net::HTTP).to receive(:new).with("www.example.com", 443).and_return(@http)
+    allow(@http).to receive(:start).and_yield(@http)
+    allow(@http).to receive(:use_ssl=).with(true)
+    @writer = Gcs::GcsWriter.new(@gcs_api, "gs://mybucket/myobject")
+  end
+
+  describe "#start" do
+    it "yield block and ensure to close" do
+      res = double(:res, code: "201")
+      expect(@http).to receive(:put).with("/path?session=xxxxx", "", {"Content-Range" => "bytes */0", "Content-Length" => "0" }).and_return(res)
+      @writer.start do |o|
+        expect(o).to be(o)
+      end
+    end
+  end
+
+  describe "#write" do
+    context "write string under chunk size" do
+      before do
+        @writer.write("foo")
+      end
+      it "flush buffer at close" do
+        res = double(:res, code: "201")
+        expect(@http).to receive(:put).with("/path?session=xxxxx", "foo", {"Content-Range" => "bytes 0-2/3", "Content-Length" => "3" }).and_return(res)
+        @writer.close
+      end
+    end
+
+    context "write string larger than chunk size" do
+      it "write 2 chunks" do
+        buf = "a" * Gcs::GcsWriter::CHUNK_SIZE + "b"
+        res = double(:res, code: "308")
+        expect(@http).to receive(:put).with("/path?session=xxxxx", "a" * Gcs::GcsWriter::CHUNK_SIZE, {"Content-Range" => "bytes 0-#{Gcs::GcsWriter::CHUNK_SIZE-1}/*", "Content-Length" => Gcs::GcsWriter::CHUNK_SIZE.to_s }).and_return(res)
+        @writer.write(buf)
+
+        # remaining buffer should be flushed at `close`
+        res = double(:res, code: "201")
+        expect(@http).to receive(:put).with("/path?session=xxxxx", "b", {"Content-Range" => "bytes #{Gcs::GcsWriter::CHUNK_SIZE}-#{Gcs::GcsWriter::CHUNK_SIZE}/#{Gcs::GcsWriter::CHUNK_SIZE+1}", "Content-Length" => "1" }).and_return(res)
+        @writer.close
+      end
+    end
+  end
+end


### PR DESCRIPTION
Gcs::GcsWriter is the utility class which allow you to easily use Gcs#initiate_resumable_upload and the following http requests. 

Synopsis

```
api = Gcs.new
writer = Gcs::GcsWriter.new(api, "gs://mybucket/myobject", content_type: "application/json")
writer.write(str1)
writer.write(str2)
writer.close
```
or
```
api = Gcs.new
writer = Gcs::GcsWriter.new(api, "gs://mybucket/myobject", content_type: "application/json")
writer.start do |io|
  io.write(str1)
end
```